### PR TITLE
Add the possibility of silencing the output of the plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The following are all possible configuration options:
 		<td>false</td>
 		<td>Search directories defined in `searchPaths` recursively.</td>
 	</tr>
+    <tr>
+        <td>silent</td>
+        <td>false</td>
+        <td>Suppress the log output of the task. </td>
+    </tr>	
 </table>
 
 Those are the configuration options, as in an `build.gradle` file, with their default values:
@@ -79,5 +84,6 @@ yamlValidator {
     searchPaths = ['src/main/resources/']
     allowDuplicates = false
     searchRecursive = false
+    silent = false
 }
 ```

--- a/src/main/java/at/zierler/gradle/NullLogger.java
+++ b/src/main/java/at/zierler/gradle/NullLogger.java
@@ -1,0 +1,71 @@
+package at.zierler.gradle;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+
+class NullLogger extends org.slf4j.helpers.NOPLogger implements Logger {
+
+    static NullLogger NULL_LOGGER = new NullLogger();
+
+    private NullLogger() {}
+
+    @Override
+    public boolean isLifecycleEnabled() {
+        return false;
+    }
+
+    @Override
+    public void lifecycle(String message) {
+
+    }
+
+    @Override
+    public void lifecycle(String message, Object... objects) {
+
+    }
+
+    @Override
+    public void lifecycle(String message, Throwable throwable) {
+
+    }
+
+    @Override
+    public boolean isQuietEnabled() {
+        return false;
+    }
+
+    @Override
+    public void quiet(String message) {
+
+    }
+
+    @Override
+    public void quiet(String message, Object... objects) {
+
+    }
+
+    @Override
+    public void quiet(String message, Throwable throwable) {
+
+    }
+
+    @Override
+    public boolean isEnabled(LogLevel level) {
+        return false;
+    }
+
+    @Override
+    public void log(LogLevel level, String message) {
+
+    }
+
+    @Override
+    public void log(LogLevel level, String message, Object... objects) {
+
+    }
+
+    @Override
+    public void log(LogLevel level, String message, Throwable throwable) {
+
+    }
+}

--- a/src/main/java/at/zierler/gradle/ValidationProperties.java
+++ b/src/main/java/at/zierler/gradle/ValidationProperties.java
@@ -13,5 +13,5 @@ public class ValidationProperties {
     private List<String> searchPaths = Collections.singletonList(DEFAULT_DIRECTORY);
     private boolean allowDuplicates = false;
     private boolean searchRecursive = false;
-
+    private boolean silent = false;
 }

--- a/src/test/java/at/zierler/gradle/YamlValidatorPluginIntTest.java
+++ b/src/test/java/at/zierler/gradle/YamlValidatorPluginIntTest.java
@@ -185,6 +185,18 @@ public class YamlValidatorPluginIntTest {
         assertThat(output, containsString(expectedLineInOutput));
     }
 
+    @Test
+    public void shouldProduceNoOutputWhenSilent() {
+        writeFile("plugins { id 'at.zierler.yamlvalidator' }\n" +
+                "yamlValidator { silent = true }", buildFile);
+        String output = GradleRunner
+                .create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withPluginClasspath()
+                .withArguments(VALIDATE_YAML_TASK_NAME).build().getOutput();
+        assertThat(output, not(containsString("YAML")));
+    }
+
     private void writeBuildFileWithoutProperties() {
 
         writeFile(


### PR DESCRIPTION
When running this in a project with large amounts of YAML files,
the logs will be overflowing with output from the plugin.

Therefore, let's introduce a configuration option `silent`.